### PR TITLE
Added C++ tcso

### DIFF
--- a/C++/readme.md
+++ b/C++/readme.md
@@ -1,0 +1,12 @@
+# TcSo C++
+This contains the CPP version of the Try Catch stack overflow for Linux. Use the try catch block used in [tcso_linux.cpp](tcso_linux.cpp). Please also include cstdlib for the 'system' command. You can use it in your projects. Please don't forget to make improvements and submit a new pull request.
+
+#### Requirements
+* g++
+* A web browser
+
+#### Credits
+Developed by: [Sai Vemprala](https://github.com/saihv)
+
+###### Contributors
+* {your-nam-here}

--- a/C++/tcso_linux.cpp
+++ b/C++/tcso_linux.cpp
@@ -1,0 +1,10 @@
+#include <iostream>
+#include <cstdlib>
+
+try {
+        // Bad code goes here
+}
+catch (const std::exception &e) {
+    std::string cmd = "xdg-open 'https://stackoverflow.com/search?q=" + std::string(e.what()) + "'";
+    system(cmd.c_str());
+}


### PR DESCRIPTION
This commit adds a simple tcso for C++ that works on Linux. Opens the default browser on catching an exception through the `xdg-open` command. 